### PR TITLE
Update config to docs.hazelcast.org

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,8 +4,16 @@
 :url-docs-ui: https://github.com/JakeSCahill/hazelcast-docs-ui
 :url-asciidoc-extensions: https://asciidoctor-docs.netlify.app/asciidoctor.js/latest/extend/extensions
 :url-contributing: .github/CONTRIBUTING.adoc
+:url-netlify: https://netlify.com/
+:url-netlify-docs: https://docs.netlify.com/
+:url-production: https://docs.hazelcast.com
+:url-staging: https://develop--laughing-jepsen-c9f089.netlify.app/home/index.html
 
-image:https://img.shields.io/github/workflow/status/JakeSCahill/hazelcast-docs/Build%20site?label=Build[GitHub Workflow Status] image:https://img.shields.io/github/workflow/status/JakeSCahill/hazelcast-docs/Index%20site?label=Indexer[GitHub Workflow Status] image:https://img.shields.io/github/workflow/status/JakeSCahill/hazelcast-docs/Publish?label=GitHub%20Pages[GitHub Workflow Status]
+
+image:https://img.shields.io/github/workflow/status/JakeSCahill/hazelcast-docs/Index%20site?label=Indexer[GitHub Workflow Status]
+image:https://api.netlify.com/api/v1/badges/77888641-0e64-4263-8155-1e0e0b50e74e/deploy-status[Netlify deploy status]
+image:https://img.shields.io/badge/Build-Production-blue[link="{url-production}"]
+image:https://img.shields.io/badge/Build-Staging-yellow[link="{url-staging}"]
 
 This repository hosts an {url-antora}[Antora] playbook project for the Hazelcast documentation site.
 
@@ -58,6 +66,15 @@ The custom extension in the `lib/` directory processes the Asciidoc `tabs` block
 
 For more information about writing Asciidoctor.js extensions, see the {url-asciidoc-extensions}[Asciidoctor docs].
 
+== Production and Staging Sites
+
+The documentation site is hosted on {url-netlify}[Netlify], which builds two versions of the site from this GitHub repository:
+
+- {url-production}[Production site]: This site is hosted on {url-production} and is built from the `main` branch
+- {url-staging}[Staging site]: This site is hosted on {url-staging} and is built from the `develop` branch
+
+To preview changes, all pull requests are made to the `develop` branch. When the team are happy with the changes, the `develop` branch is merged into the `main` branch to deploy the changes to the production site.
+
 == GitHub Actions
 
 To automate some elements of the build process, this repository includes the following GitHub Actions:
@@ -71,6 +88,20 @@ To automate some elements of the build process, this repository includes the fol
 |Runs the Docsearch indexer in a Docker container to index the site and send the index to Algolia
 |Once per day at 00:00 UTC
 |===
+
+As well as these actions, repositories that are listed under the `content.sources` field in the `antora-playbook.yml` file also include GitHub actions to trigger builds of the staging site.
+
+```yaml
+content:
+  sources: 
+  - url: https://github.com/JakeSCahill/imdg-docs
+    branches: [master, v*]
+    start_path: docs
+```
+
+Whenever content in the repository's listed branches are changed, the GitHub Action sends a {url-netlify-docs}/configure-builds/build-hooks/[build hook] to Netlify to trigger a new build of the staging site.
+
+For an example of these GitHub Actions, see the {url-imdg-docs}[IMDG documentation repository].
 
 == Contributing
 

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -1,7 +1,7 @@
 site:
   title: Documentation
   start_page: home::index.adoc
-  url: https://laughing-jepsen-c9f089.netlify.app
+  url: https://docs.hazelcast.com
   keys:
     google_analytics: 'GTM-M267KFN'
     docsearch_id: '3L6KPQWLIB'

--- a/search-config.json
+++ b/search-config.json
@@ -2,7 +2,7 @@
   "index_name": "dev_DOCS",
   "start_urls": [
     {
-      "url": "https://laughing-jepsen-c9f089.netlify.app/imdg/(?P<version>.*?)/",
+      "url": "https://docs.hazelcast.com/imdg/(?P<version>.*?)/",
       "variables": {
         "version": ["latest"]
       },
@@ -10,7 +10,7 @@
     }
   ],
   "sitemap_urls": [
-    "https://laughing-jepsen-c9f089.netlify.app/sitemap-imdg.xml"
+    "https://docs.hazelcast.com/sitemap-imdg.xml"
   ],
   "stop_urls": [],
   "selectors": {


### PR DESCRIPTION
# Description of change

Added docs.hazelcast.com as the new url

## Type of change

Select the type of change you're making by adding an X to the box:

- [x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [x] Update the README with links to staging and production sites and a description of Netlify/workflow